### PR TITLE
Add introduction to Owl dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Neural Network module of [Owl](https://github.com/ryanrhymes/owl).
 Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and
 [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html).
 
-You can get all these data in `Owl` by excuting: `Dataset.download_all ()`.
+You can get all these data in `Owl` by executing: `Dataset.download_all ()`.
 The downloaded data are stored in the home directory, for example,  `~/.owl/dataset` on Linux.
 
 ## MNIST
@@ -25,8 +25,7 @@ You can get MNIST data via these `Owl` functions:
   Similar to `load_mnist_train_data`, only that it returns the test set, so
   the example size is 10, 000 instead of 60, 000.
 
-- `Dataset.load_mnist_train_data_arr ()`: similar to `load_mnist_train_data`,   
-but returns `x` as [60000,28,28,1] ndarray
+- `Dataset.load_mnist_train_data_arr ()`: similar to `load_mnist_train_data`,   but returns `x` as [60000,28,28,1] ndarray
 
 - `Dataset.load_mnist_test_data_arr ()`: similar to
   `load_mnist_train_data_arr`, but it returns the test set, so the example size
@@ -43,7 +42,7 @@ batch. You can get CIFAR-10 data using `Owl`:
 - `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`.
   + The input `batch` can range from 1 to 5, indicating which training set batch to choose.
   + `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
-  dimension indicats color channels (first Red, then Green, finally Blue).
+  dimension indicates color channels (first Red, then Green, finally Blue).
   + Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
   an image class.
   + `y'` is the corresponding 10000 x 10 one-hot label matrix.  

--- a/README.md
+++ b/README.md
@@ -1,1 +1,17 @@
-# dataset
+# Owl Dataset
+
+This repository provides easy access to various datasets to be used in the Neural Network module of [Owl](https://github.com/ryanrhymes/owl).
+Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html).
+
+You can get all these data in `Owl` by running: `download_data fname ();;`.
+
+## MNIST
+
+The MNIST database of handwritten digits, available from this page, has a training set of 60,000 examples, and a test set of 10,000 examples. Each example is of size 28 x 28.
+
+You can get MNIST data via these functions:
+
+- `load_mnist_train_data ()`: return a triplet.
+   The first is a 60000 x 784 matrix where each row represent a 28 x 28 image.
+   The second is label
+   The third is the corresponding unravelled row vector of the label.

--- a/README.md
+++ b/README.md
@@ -6,24 +6,25 @@ Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and
 [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html).
 
 You can get all these data in `Owl` by executing: `Dataset.download_all ()`.
-The downloaded data are stored in the home directory, for example,  `~/.owl/dataset` on Linux.
+Thedata are downloaded in the home directory, for example,  `~/.owl/dataset` on Linux.
 
 ## MNIST
 
-The MNIST database of handwritten digits, available from this page, has a training set of 60,000 examples, and a test set of 10,000 examples. Each example is of size 28 x 28.
+The MNIST database of handwritten digits has a training set of 60,000 examples,
+and a test set of 10,000 examples. Each example is of size 28 x 28.
 
 You can get MNIST data via these `Owl` functions:
 
-- `Dataset.load_mnist_train_data ()`: return a triplet `x, y, y'`.
-  + `x` is a 60000 x 784 matrix (`Owl_dense_matrix.S.mat`) where each row represent a 28 x 28 image.
+- `Dataset.load_mnist_train_data ()`: returns a triplet `x, y, y'`.
+  + `x` is a 60000 x 784 matrix (`Owl_dense_matrix.S.mat`) where each row represents a 28 x 28 image.
   + `y` is a 60000 x 1 label matrix. Each row is an integer ranging from 0 to 9,
   indicating the digit on each image.
-  + `y'` is a 60000 x 10 label matrix. Each one-hot row vector corresponding to
+  + `y'` is a 60000 x 10 label matrix. Each one-hot row vector corresponds to
   one label.
 
-- `Dataset.load_mnist_test_data ()`: return a triplet.
+- `Dataset.load_mnist_test_data ()`: returns a triplet.
   Similar to `load_mnist_train_data`, only that it returns the test set, so
-  the example size is 10, 000 instead of 60, 000.
+  the example size is 10,000 instead of 60,000.
 
 - `Dataset.load_mnist_train_data_arr ()`: similar to `load_mnist_train_data`,   but returns `x` as [60000,28,28,1] ndarray
 
@@ -34,18 +35,18 @@ You can get MNIST data via these `Owl` functions:
 - `Dataset.draw_samples x y n` draws `n` random examples from images matrix `x` and lable matrix `y`.  
 
 ## CIFAR-10
-The CIFAR-10 dataset consists of 60000 32 x 32 colour images in 10 classes,
-with 6000 images per class. There are 50000 training images and 10000 test
+The CIFAR-10 dataset consists of 60,000 32 x 32 colour images in 10 classes,
+with 6,000 images per class. There are 50,000 training images and 10,000 test
 images.
 
 Due to the limit of file size on Github, the training set is cut into 5 smaller
 batch. You can get CIFAR-10 data using `Owl`:
 
-- `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`.
+- `Dataset.load_cifar_train_data batch`: returns a triplet `x, y, y'`.
   + The input paramter `batch` can range from 1 to 5, indicating which training set batch to choose.
-  + `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
+  + `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The last
   dimension indicates color channels (first Red, then Green, finally Blue).
-  + Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
+  + `y` is an 10000 x 1 label matrix, each number representing
   an image class.
   + `y'` is the corresponding 10000 x 10 one-hot label matrix.  
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@ Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and
 [CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html).
 
 You can get all these data in `Owl` by excuting: `Dataset.download_all ()`.
-The downloaded data are stored in the home directory, for example,  
-`~/.owl/dataset` on Linux.
+The downloaded data are stored in the home directory, for example,  `~/.owl/dataset` on Linux.
 
 ## MNIST
 
@@ -16,20 +15,18 @@ The MNIST database of handwritten digits, available from this page, has a traini
 You can get MNIST data via these `Owl` functions:
 
 - `Dataset.load_mnist_train_data ()`: return a triplet `x, y, y'`.
-  `x` is a 60000 x 784 matrix where each row represent a 28 x 28 image.
-  `y` is a 60000 x 1 label matrix. Each row is an integer ranging from 0 to 9,
+  + `x` is a 60000 x 784 matrix (`Owl_dense_matrix.S.mat`) where each row represent a 28 x 28 image.
+  + `y` is a 60000 x 1 label matrix. Each row is an integer ranging from 0 to 9,
   indicating the digit on each image.
-  `y'` is a 60000 x 10 label matrix. Each one-hot row vector corresponding to
+  + `y'` is a 60000 x 10 label matrix. Each one-hot row vector corresponding to
   one label.
-  All three matrix are of type `Owl_dense_matrix.S.mat`, which means that all
-  elements are of `float32` format.
 
 - `Dataset.load_mnist_test_data ()`: return a triplet.
   Similar to `load_mnist_train_data`, only that it returns the test set, so
   the example size is 10, 000 instead of 60, 000.
 
 - `Dataset.load_mnist_train_data_arr ()`: similar to `load_mnist_train_data`,   
-  but returns `x` as [60000,28,28,1] ndarray
+but returns `x` as [60000,28,28,1] ndarray
 
 - `Dataset.load_mnist_test_data_arr ()`: similar to
   `load_mnist_train_data_arr`, but it returns the test set, so the example size
@@ -43,13 +40,15 @@ images.
 Due to the limit of file size on Github, the training set is cut into 5 smaller
 batch. You can get CIFAR-10 data using `Owl`:
 
-- `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`. The input
-  `batch` can range from 1 to 5, indicating which training set batch to choose.
-  `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
+- `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`.
+  + The input `batch` can range from 1 to 5, indicating which training set batch to choose.
+  + `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
   dimension indicats color channels (first Red, then Green, finally Blue).
-  Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
-  an image class, and `y'` is the corresponding 10000 x 10 one-hot label
-  matrix.  
+  + Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
+  an image class.
+  + `y'` is the corresponding 10000 x 10 one-hot label matrix.  
 
 - `Dataset.load_cifar_test_data ()`: similar to `load_cifar_train_data`, only
   that it loads test data.
+
+Note that all elements in the loaded matrices and ndarrays are of `float32` format.

--- a/README.md
+++ b/README.md
@@ -1,17 +1,55 @@
 # Owl Dataset
 
-This repository provides easy access to various datasets to be used in the Neural Network module of [Owl](https://github.com/ryanrhymes/owl).
-Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and [CIFAR10](https://www.cs.toronto.edu/~kriz/cifar.html).
+This repository provides easy access to various datasets to be used in the
+Neural Network module of [Owl](https://github.com/ryanrhymes/owl).
+Currently it mainly includes [MNIST](http://yann.lecun.com/exdb/mnist/) and
+[CIFAR-10](https://www.cs.toronto.edu/~kriz/cifar.html).
 
-You can get all these data in `Owl` by running: `download_data fname ();;`.
+You can get all these data in `Owl` by excuting: `Dataset.download_all ()`.
+The downloaded data are stored in the home directory, for example,  
+`~/.owl/dataset` on Linux.
 
 ## MNIST
 
 The MNIST database of handwritten digits, available from this page, has a training set of 60,000 examples, and a test set of 10,000 examples. Each example is of size 28 x 28.
 
-You can get MNIST data via these functions:
+You can get MNIST data via these `Owl` functions:
 
-- `load_mnist_train_data ()`: return a triplet.
-   The first is a 60000 x 784 matrix where each row represent a 28 x 28 image.
-   The second is label
-   The third is the corresponding unravelled row vector of the label.
+- `Dataset.load_mnist_train_data ()`: return a triplet `x, y, y'`.
+  `x` is a 60000 x 784 matrix where each row represent a 28 x 28 image.
+  `y` is a 60000 x 1 label matrix. Each row is an integer ranging from 0 to 9,
+  indicating the digit on each image.
+  `y'` is a 60000 x 10 label matrix. Each one-hot row vector corresponding to
+  one label.
+  All three matrix are of type `Owl_dense_matrix.S.mat`, which means that all
+  elements are of `float32` format.
+
+- `Dataset.load_mnist_test_data ()`: return a triplet.
+  Similar to `load_mnist_train_data`, only that it returns the test set, so
+  the example size is 10, 000 instead of 60, 000.
+
+- `Dataset.load_mnist_train_data_arr ()`: similar to `load_mnist_train_data`,   
+  but returns `x` as [60000,28,28,1] ndarray
+
+- `Dataset.load_mnist_test_data_arr ()`: similar to
+  `load_mnist_train_data_arr`, but it returns the test set, so the example size
+  is 10, 000 instead of 60, 000.
+
+## CIFAR-10
+The CIFAR-10 dataset consists of 60000 32 x 32 colour images in 10 classes,
+with 6000 images per class. There are 50000 training images and 10000 test
+images.
+
+Due to the limit of file size on Github, the training set is cut into 5 smaller
+batch. You can get CIFAR-10 data using `Owl`:
+
+- `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`. The input
+  `batch` can range from 1 to 5, indicating which training set batch to choose.
+  `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
+  dimension indicats color channels (first Red, then Green, finally Blue).
+  Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
+  an image class, and `y'` is the corresponding 10000 x 10 one-hot label
+  matrix.  
+
+- `Dataset.load_cifar_test_data ()`: similar to `load_cifar_train_data`, only
+  that it loads test data.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ You can get MNIST data via these `Owl` functions:
   `load_mnist_train_data_arr`, but it returns the test set, so the example size
   is 10, 000 instead of 60, 000.
 
+- `Dataset.draw_samples x y n` draws `n` random examples from images matrix `x` and lable matrix `y`.  
+
 ## CIFAR-10
 The CIFAR-10 dataset consists of 60000 32 x 32 colour images in 10 classes,
 with 6000 images per class. There are 50000 training images and 10000 test
@@ -40,7 +42,7 @@ Due to the limit of file size on Github, the training set is cut into 5 smaller
 batch. You can get CIFAR-10 data using `Owl`:
 
 - `Dataset.load_cifar_train_data batch`: return a triplet `x, y, y'`.
-  + The input `batch` can range from 1 to 5, indicating which training set batch to choose.
+  + The input paramter `batch` can range from 1 to 5, indicating which training set batch to choose.
   + `x` is an [10000, 32, 32, 3] ndarry (`Owl_dense_ndarray.S.arr`). The final
   dimension indicates color channels (first Red, then Green, finally Blue).
   + Similar to MNIST, `y` is an 10000 x 1 label matrix, each number representing
@@ -49,5 +51,7 @@ batch. You can get CIFAR-10 data using `Owl`:
 
 - `Dataset.load_cifar_test_data ()`: similar to `load_cifar_train_data`, only
   that it loads test data.
+
+- `Dataset.draw_samples_cifar x y n` draws `n` random examples from images ndarray `x` and lable matrix `y`.
 
 Note that all elements in the loaded matrices and ndarrays are of `float32` format.


### PR DESCRIPTION
I this PR I've added brief introductions to MNIST and CIFAR-10 datasets, how to load them into `Owl`, and the output formats. 